### PR TITLE
feat(*): Add a callback for object ID labels

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,10 @@ Constructs a new JSONEditor.
 
   Set a callback function  to determine whether individual nodes are editable or read-only. Only applicable when option `mode` is `tree`. The callback is invoked as `editable(node)`, where `node` is an object `{field: string, value: string, path: string[]}`. The function must either return a boolean value to set both the nodes field and value editable or read-only, or return an object `{field: boolean, value: boolean}`.
 
+- `{function} onObjectID`
+
+  Set a callback function to determine the ID field for a node of type "object". Applicable when option `mode` is `tree`, `view`, or `form`. The callback is invoked as `onObjectID(path)`, where `path` is a `string[]`. The function must return a string indicating the field designated as the ID field. In the case that an object doesn't have an identifier field, the function may return an empty string, `null`, or `undefined`.
+
 - `{function} onError`
 
   Set a callback function triggered when an error occurs. Invoked with the error as first argument. The callback is only invoked

--- a/examples/08_object_id_labels.html
+++ b/examples/08_object_id_labels.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>JSONEditor | Basic usage</title>
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    #jsoneditor {
+      width: 500px;
+      height: 500px;
+    }
+  </style>
+</head>
+<body>
+<p>
+  <button id="setJSON">Set JSON</button>
+  <button id="getJSON">Get JSON</button>
+</p>
+<div id="jsoneditor"></div>
+
+<script>
+  // create the editor
+  var container = document.getElementById('jsoneditor');
+  var options = {
+    onObjectID: function onObjectID(path) {
+      if (path[0] === 'campaignList' && typeof path[1] === 'number') {
+        return 'payName';
+      }
+    }
+  };
+  var json = {
+    campaignList: [
+      {
+        payName: 'test payname 1'
+      },
+      {
+        payName: 'test payname 2'
+      },
+      {
+        payName: 'test payname 3'
+      },
+    ]
+  };
+  var editor = new JSONEditor(container, options, json);
+
+  // set json
+  document.getElementById('setJSON').onclick = function () {
+    var json = {
+      'array': [1, 2, 3],
+      'boolean': true,
+      'null': null,
+      'number': 123,
+      'object': {'a': 'b', 'c': 'd'},
+      'string': 'Hello World'
+    };
+    editor.set(json);
+  };
+
+  // get json
+  document.getElementById('getJSON').onclick = function () {
+    var json = editor.get();
+    alert(JSON.stringify(json, null, 2));
+  };
+</script>
+</body>
+</html>

--- a/src/css/jsoneditor.css
+++ b/src/css/jsoneditor.css
@@ -106,6 +106,10 @@ div.jsoneditor-value.jsoneditor-array {
   color: #808080;
 }
 
+div.jsoneditor-value.jsoneditor-object span {
+  color: #2FB556;
+}
+
 div.jsoneditor-value.jsoneditor-number {
   color: #ee422e;
 }

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -81,7 +81,7 @@ function JSONEditor (container, options, json) {
       var VALID_OPTIONS = [
         'ace', 'theme',
         'ajv', 'schema',
-        'onChange', 'onEditable', 'onError', 'onModeChange',
+        'onChange', 'onEditable', 'onObjectID', 'onError', 'onModeChange',
         'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation', 'sortObjectKeys'
       ];
 

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -73,6 +73,23 @@ Node.prototype._updateEditability = function () {
 };
 
 /**
+ * Determine the ID of a node if the node's type is "object".
+ * @private
+ */
+Node.prototype._updateObjectID = function() {
+  this.objectID = '';
+
+  if (!this.editor) return;
+  if (this.editor.options.mode !== 'tree' &&
+      this.editor.options.mode !== 'form' &&
+      this.editor.options.mode !== 'view') return;
+  if (typeof this.editor.options.onObjectID !== 'function') return;
+
+  var idField = this.editor.options.onObjectID(this.getPath());
+  if (idField) this.objectID = idField;
+};
+
+/**
  * Get the path of this node
  * @return {String[]} Array containing the path to this node
  */
@@ -1474,6 +1491,7 @@ Node.prototype.getDom = function() {
   }
 
   this._updateEditability();
+  this._updateObjectID();
 
   // create row
   dom.tr = document.createElement('tr');
@@ -1949,7 +1967,20 @@ Node.prototype.updateDom = function (options) {
       util.addClassName(this.dom.tr, 'jsoneditor-expandable');
     }
     else if (this.type == 'object') {
-      domValue.innerHTML = '{' + count + '}';
+      var objectID = this.objectID;
+      var idNode = this.childs && this.childs.find(function(node) {
+        return node && node.field === objectID;
+      });
+
+      if (idNode && idNode.field && idNode.value) {
+        domValue.innerHTML =
+          '{' + count + '} ' +
+          '<span>' + idNode.field + ': ' + idNode.value + '</span>';
+      }
+      else {
+        domValue.innerHTML = '{' + count + '}';
+      }
+
       util.addClassName(this.dom.tr, 'jsoneditor-expandable');
     }
     else {


### PR DESCRIPTION
This is useful when you want your object nodes to show more context. Example:

```js
const json = {
  "campaignList": [
    {
      "name": "Halloween Promotion",
      "foo": "bar",
      "baz": "quz"
    }
  ]
}

const options = {
  onObjectID(jsonPath) {
    if (jsonPath[0] === 'campaignList' && typeof jsonPath[1] === 'number') {
      return 'name'
    }
  }
}

const editor = new JSONEditor(element, options, json)
```

As you can see, `onObjectID` expects the JSON path as input, and returns the name of the ID key within the object. In the browser, the value of the ID key is then displayed next to the object node. For the example above, the value would be `"Halloween Promotion"`.

This is a temporary hack intended for use within internal tools at Rising Tide Games (a game studio under Zynga). The JSON editor rewrite mentioned in josdejong/jsoneditor#337 may make this hack unnecessary.